### PR TITLE
feat: add notification preferences for scheduled notifications

### DIFF
--- a/src/notification-preferences/NotificationPreferenceColumn.jsx
+++ b/src/notification-preferences/NotificationPreferenceColumn.jsx
@@ -39,12 +39,18 @@ const NotificationPreferenceColumn = ({ appId, channel, appPreference }) => {
     return checked;
   }, []);
 
-  const getEmailCadence = useCallback((notificationChannel, checked, innerText, emailCadence) => {
+  const getEmailCadence = useCallback((
+    notificationChannel,
+    checked,
+    innerText,
+    emailCadence,
+    cadenceLocked = false,
+  ) => {
     if (notificationChannel === EMAIL_CADENCE) {
       return innerText;
     }
     if (notificationChannel === EMAIL && checked) {
-      return EMAIL_CADENCE_PREFERENCES.DAILY;
+      return cadenceLocked ? emailCadence : EMAIL_CADENCE_PREFERENCES.DAILY;
     }
     return emailCadence;
   }, []);
@@ -59,6 +65,7 @@ const NotificationPreferenceColumn = ({ appId, channel, appPreference }) => {
       checked,
       innerText,
       appNotificationPreference.emailCadence,
+      appNotificationPreference.cadenceLocked,
     );
 
     dispatch(updatePreferenceToggle(
@@ -96,7 +103,7 @@ const NotificationPreferenceColumn = ({ appId, channel, appPreference }) => {
         onToggle={onToggle}
         emailCadence={preference.emailCadence}
         notificationType={preference.id}
-        disabled={nonEditable[preference.id]?.includes(channel)}
+        disabled={nonEditable[preference.id]?.includes(channel) || preference.cadenceLocked}
       />
       )}
     </div>
@@ -131,6 +138,7 @@ NotificationPreferenceColumn.propTypes = {
   appPreference: PropTypes.shape({
     id: PropTypes.string,
     emailCadence: PropTypes.string,
+    cadenceLocked: PropTypes.bool,
     appId: PropTypes.string,
     info: PropTypes.string,
     email: PropTypes.bool,

--- a/src/notification-preferences/data/thunks.js
+++ b/src/notification-preferences/data/thunks.js
@@ -50,6 +50,7 @@ const normalizePreferences = (responseData) => {
         info: preferences[appId].notificationTypes[preferenceId].info || '',
         emailCadence: preferences[appId].notificationTypes[preferenceId].emailCadence
         || EMAIL_CADENCE_PREFERENCES.DAILY,
+        cadenceLocked: preferences[appId].notificationTypes[preferenceId].cadenceLocked || false,
         coreNotificationTypes: preferences[appId].coreNotificationTypes || [],
       }
     ));
@@ -122,7 +123,7 @@ export const updatePreferenceToggle = (
         const emailCadenceData = await togglePreference(
           EMAIL_CADENCE,
           value,
-          EMAIL_CADENCE_PREFERENCES.DAILY,
+          emailCadence || EMAIL_CADENCE_PREFERENCES.DAILY,
         );
 
         handleSuccessResponse(emailCadenceData);

--- a/src/notification-preferences/messages.js
+++ b/src/notification-preferences/messages.js
@@ -14,6 +14,9 @@ const messages = defineMessages({
       coursework {Course Work}
       updates {Updates}
       grading {Grading}
+      calendar {Calendar}
+      requests {Requests}
+      learning {Learning}
       other {{key}}
     }`,
     description: 'Display text for Notification Types',
@@ -30,6 +33,29 @@ const messages = defineMessages({
       oraStaffNotifications {New ORA submission for staff grading}
       oraGradeAssigned {Essay assignment grade received}
       newInstructorAllLearnersPost {New posts from instructors}
+      sessionScheduled {New session scheduled}
+      sessionCancelled {Session cancelled}
+      sessionRescheduled {Session rescheduled}
+      sessionAssigned {Session assigned}
+      substituteAssigned {Assigned as substitute}
+      sessionScheduleChanged {Session schedule changed}
+      substituteNeeded {Substitute needed}
+      newLeaveRequest {New leave request}
+      leaveRequestUpdate {Leave request updates}
+      newRemoteSessionRequest {New remote session request}
+      remoteSessionUpdate {Remote session request updates}
+      newProfileUpdateRequest {New profile update request}
+      profileUpdateRequest {Profile update request updates}
+      instructorCourseAdded {Added as course instructor}
+      traineeEnrolledInProgram {Enrolled in program}
+      adminTraineeEnrolled {Trainee enrolled in program}
+      newUserCreated {New user created}
+      newUserInRegion {New user in your region}
+      userActivated {User account activated}
+      userDeactivated {User account deactivated}
+      accountActivated {Your account has been activated}
+      sessionReminder {Session reminder}
+      assignmentDueReminder {Assignment due reminder}
       other {{text}}
     }`,
     description: 'Display text for Notification Types',


### PR DESCRIPTION
 ## Summary                                             

  - Add sessionReminder and assignmentDueReminder to the notification                                                                                                       
    title message catalogue with info tooltips showing when each fires
    (~1 hour before session / 8 AM PKT for next-day assignments)                                                                                                            
  - Extract cadenceLocked from the preferences API response in                                                                                                              
    normalizePreferences and carry it through Redux so components know
    which types have a fixed send frequency                                                                                                                                 
  - Disable the email cadence dropdown for cadence-locked types so users
    cannot change the frequency on time-sensitive notifications                                                                                                             
  - Fix cadence resetting to Daily when email is toggled off then back on
    for a locked type — preserve the stored cadence instead of defaulting                                                                                                   
  - Fix secondary email_cadence PUT in updatePreferenceToggle that always
    sent Daily regardless of computed cadence, causing Redux state to show                                                                                                  
    the wrong value until page reload                    
                                                                                                                                                                            
  ## Files changed                                       

  - messages.js: new sessionReminder and assignmentDueReminder entries                                                                                                      
    in notificationTitle; info strings for both types
  - data/thunks.js: extract cadenceLocked in normalizePreferences; fix                                                                                                      
    secondary cadence PUT to use computed value instead of hardcoded Daily                                                                                                  
  - NotificationPreferenceColumn.jsx: disable cadence dropdown when
    cadenceLocked; preserve locked cadence on email re-enable  